### PR TITLE
Fix: avoid hanging process with empty input files in MAF combination …

### DIFF
--- a/workflow/rules/ffpe.smk
+++ b/workflow/rules/ffpe.smk
@@ -152,7 +152,8 @@ rule collect_ffpefilter_mafs:
   shell:"""    
     date
     echo "Combining MAFs..."
-    awk 'FNR==1 && NR!=1 {{ while (/^#/||/^Hugo_Symbol/) getline; }} 1 {{print}}' {input.mafs} > {output.maf}
+    head -2 {input.mafs[0]} > {output.maf}
+    awk 'FNR>2 {{print}}' {input.mafs} >> {output.maf}
     echo "Done..."
     date
   """

--- a/workflow/rules/somatic_snps.common.smk
+++ b/workflow/rules/somatic_snps.common.smk
@@ -103,7 +103,8 @@ rule collect_cohort_mafs:
   shell:"""    
     date
     echo "Combining MAFs..."
-    awk 'FNR==1 && NR!=1 {{ while (/^#/||/^Hugo_Symbol/) getline; }} 1 {{print}}' {input.mafs} > {output.maf}
+    head -2 {input.mafs[0]} > {output.maf}
+    awk 'FNR>2 {{print}}' {input.mafs} >> {output.maf}
     echo "Done..."
     date
   """


### PR DESCRIPTION
Resolves an issue where a while loop creates a hanging process when input file(s) are empty