### PR TITLE
Updating base image and converting germline rules 

### DIFF
--- a/config/containers/images.json
+++ b/config/containers/images.json
@@ -1,5 +1,6 @@
 {
     "images": {
+        "wes_base": "docker://nciccbr/ccbr_wes_base:v0.1.0",
         "fastq_screen": "docker://nciccbr/ccbr_fastq_screen_0.13.0:v2.0",
         "fastqc": "docker://nciccbr/ccbr_fastqc_0.11.9:v1.1",
         "fastqvalidator": "docker://nciccbr/ccbr_fastqvalidator:v0.1.0",

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -93,6 +93,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
 # bwa/0.7.17  bowtie/1.2.3  bowtie2/2.3.5.1 
 # bedtools/2.27.1  bedops/2.4.37  samtools/1.10 
 # bcftools/1.10.2  vcftools/0.1.16  trimmomatic/0.39
+# tabix/1.10.2
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
       bcftools \
       bedops \
@@ -101,14 +102,34 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
       bowtie2 \
       bwa \
       samtools \
+      tabix \
       trimmomatic \
       vcftools
 
-# Install GATK/4.2.2
-RUN wget https://github.com/broadinstitute/gatk/archive/refs/tags/4.2.1.0.zip \
-    && unzip /opt2/4.2.1.0.zip \
-    && rm /opt2/4.2.1.0.zip
-ENV PATH="/opt2/gatk-4.2.1.0/:$PATH"
+# Install Sambamba/0.8.1 for CNTRL-Freec
+# not available to apt-get on Ubuntu 20.04
+RUN wget https://github.com/biod/sambamba/releases/download/v0.8.1/sambamba-0.8.1-linux-amd64-static.gz \
+    && gzip -d /opt2/sambamba-0.8.1-linux-amd64-static.gz \
+    && mv /opt2/sambamba-0.8.1-linux-amd64-static /opt2/sambamba \
+    && chmod a+rx /opt2/sambamba
+
+# Install GATK4 (GATK/4.2.2.0)
+# Requires Java8 or 1.8
+RUN wget https://github.com/broadinstitute/gatk/releases/download/4.2.2.0/gatk-4.2.2.0.zip \
+    && unzip /opt2/gatk-4.2.2.0.zip \
+    && rm /opt2/gatk-4.2.2.0.zip \
+    && /opt2/gatk-4.2.2.0/gatk --list
+ENV PATH="/opt2/gatk-4.2.2.0:$PATH"
+
+# Install last release of GATK3 (GATK/3.8-1)
+# Only being used for the CombineVariants
+# command that is not available in GATK4
+# Available via env variable: $GATK_JAR
+# Requires Java8 or 1.8
+RUN wget https://storage.googleapis.com/gatk-software/package-archive/gatk/GenomeAnalysisTK-3.8-1-0-gf15c1c3ef.tar.bz2 \
+    && tar -xvjf /opt2/GenomeAnalysisTK-3.8-1-0-gf15c1c3ef.tar.bz2 \
+    && rm /opt2/GenomeAnalysisTK-3.8-1-0-gf15c1c3ef.tar.bz2
+ENV GATK_JAR="/opt2/GenomeAnalysisTK-3.8-1-0-gf15c1c3ef/GenomeAnalysisTK.jar"
 
 # Install dependencies needed to add a new repository over HTTPS
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -129,13 +150,51 @@ RUN Rscript -e 'install.packages(c("argparse", "knitr", "tidyverse", "dplyr", "p
 RUN Rscript -e 'install.packages(c("shiny", "gridExtra", "flexdashboard", "rmarkdown", "crosstalk", "DT", "reshape2", "circlize", "viridis"), repos="http://cran.r-project.org")'
 RUN Rscript -e 'install.packages("BiocManager"); BiocManager::install(c("limma", "edgeR", "ComplexHeatmap"))'
 
+# Install Control-FREEC/v11.6 and additional dependencies
+# Requires R, samtools, bedtools, sambamba (already satisfied)
+# http://boevalab.inf.ethz.ch/FREEC/tutorial.html#install
+RUN wget https://github.com/BoevaLab/FREEC/archive/refs/tags/v11.6.zip \
+    && unzip /opt2/v11.6.zip \
+    && rm /opt2/v11.6.zip \
+    && cd /opt2/FREEC-11.6/src/ \
+    && make
+ENV PATH="/opt2/FREEC-11.6/src:$PATH"
+WORKDIR /opt2 
+
+# Install Sequenza-Utils/3.0.0 and Sequenza
+# Requires R, Python, SAMtools, tabix (already satisfied)
+# https://cran.r-project.org/web/packages/sequenza/vignettes/sequenza.html#getting-started
+RUN pip3 install --upgrade pip \
+	  && pip3 install sequenza-utils \
+      && Rscript -e 'BiocManager::install(c("copynumber")); install.packages(c("sequenza"), repos="http://cran.r-project.org")'
+
+# Install Somalier/v0.2.13
+# download static binary
+RUN wget https://github.com/brentp/somalier/releases/download/v0.2.13/somalier \
+    && chmod a+rx /opt2/somalier
+
+# Install VarScan/v2.4.4
+# Works with java8
+# and each wrapper script similar to HPC module
+RUN wget https://github.com/dkoboldt/varscan/raw/master/VarScan.v2.4.4.jar \
+    && echo '#!/bin/bash' > /opt2/varscan \
+    && echo 'java -jar /opt2/VarScan.v2.4.4.jar  "$@"' >> /opt2/varscan \
+    && chmod a+rx /opt2/varscan
+
 # Add Dockerfile and argparse.bash script
 # and export environment variables
+# and set java8 as default with links
+# to alternative versions
 ADD Dockerfile /opt2/base_gatk4_wes.dockerfile
 COPY argparse.bash /opt2
-RUN chmod -R a+rX /opt2 && chmod -R a+x /opt2/argparse.bash
+RUN chmod -R a+rX /opt2 \
+    && chmod -R a+x /opt2/argparse.bash \
+    && ln -s /usr/lib/jvm/java-11-openjdk-amd64/bin/java /usr/bin/java11 \
+    && ln -s /usr/lib/jvm/java-8-openjdk-amd64/bin/java /usr/bin/java8 \
+    && ln -fs /usr/lib/jvm/java-8-openjdk-amd64/bin/java /usr/bin/java
 ENV PATH="/opt2/:$PATH"
 ENV TRIMMOJAR="/usr/share/java/trimmomatic-0.39.jar"
+
 WORKDIR /data2
 
 # Clean-up step to reduce size

--- a/resources/fastq_screen.conf
+++ b/resources/fastq_screen.conf
@@ -8,8 +8,8 @@
 ## Uncomment the line below and set the appropriate location
 ##
 
-BOWTIE  /usr/local/apps/bowtie/1.2.3/bin/bowtie
-BOWTIE2 /usr/local/apps/bowtie/2-2.4.1/bin/bowtie2
+# BOWTIE  /usr/local/apps/bowtie/1.2.3/bin/bowtie
+# BOWTIE2 /usr/local/apps/bowtie/2-2.4.1/bin/bowtie2
 
 
 ############################################
@@ -19,8 +19,8 @@ BOWTIE2 /usr/local/apps/bowtie/2-2.4.1/bin/bowtie2
 ### tell the program where to find it.  Uncomment the line below and set the
 ### appropriate location. Please note, this path should INCLUDE the executable
 ### filename.
-#
-BISMARK /usr/local/apps/bismark/0.22.1/bismark
+
+# BISMARK /usr/local/apps/bismark/0.22.1/bismark
 
 
 

--- a/workflow/rules/germline.smk
+++ b/workflow/rules/germline.smk
@@ -1,4 +1,4 @@
-
+# Rules for germline variant calling
 rule haplotypecaller:
     """
     Germline variant calling. This can be done independently across the
@@ -9,8 +9,8 @@ rule haplotypecaller:
         Single-sample gVCF
     """
     input: 
-        bam=os.path.join(output_bamdir,"final_bams","{samples}.bam"),
-        bai=os.path.join(output_bamdir,"final_bams","{samples}.bai"),
+        bam = os.path.join(output_bamdir,"final_bams","{samples}.bam"),
+        bai = os.path.join(output_bamdir,"final_bams","{samples}.bai"),
     output:
         gzvcf = temp(os.path.join(output_germline_base,"gVCFs","{samples}.{chroms}.g.vcf.gz")),
         index = temp(os.path.join(output_germline_base,"gVCFs","{samples}.{chroms}.g.vcf.gz.tbi")),
@@ -21,14 +21,28 @@ rule haplotypecaller:
         chrom="{chroms}",
         ver_gatk=config['tools']['gatk4']['version'],
         rname = "hapcaller"
+    message: "Running GATK4 HaplotypeCaller on '{input.bam}' input file"
+    envmodules: 'GATK/4.2.0.0'
+    container: config['images']['wes_base']
     shell:
         """
         myoutdir="$(dirname {output.gzvcf})"
         if [ ! -d "$myoutdir" ]; then mkdir -p "$myoutdir"; fi
          
-        module load GATK/{params.ver_gatk}
-        gatk --java-options '-Xmx24g' HaplotypeCaller --reference {params.genome} --input {input.bam} --use-jdk-inflater --use-jdk-deflater --emit-ref-confidence GVCF --annotation-group StandardAnnotation --annotation-group AS_StandardAnnotation --dbsnp {params.snpsites} --output {output.gzvcf} --intervals {params.chrom} --max-alternate-alleles 3
+        gatk --java-options '-Xmx24g' HaplotypeCaller \\
+            --reference {params.genome} \\
+            --input {input.bam} \\
+            --use-jdk-inflater \\
+            --use-jdk-deflater \\
+            --emit-ref-confidence GVCF \\
+            --annotation-group StandardAnnotation \\
+            --annotation-group AS_StandardAnnotation \\
+            --dbsnp {params.snpsites} \\
+            --output {output.gzvcf} \\
+            --intervals {params.chrom} \\
+            --max-alternate-alleles 3
         """
+
 
 rule mergegvcfs:
     """
@@ -44,18 +58,28 @@ rule mergegvcfs:
     output:
         gzvcf = os.path.join(output_germline_base,"gVCFs","merged.{chroms}.g.vcf.gz"),
         index = os.path.join(output_germline_base,"gVCFs","merged.{chroms}.g.vcf.gz.tbi"),
-    # group: "merge_and_genotype"
     params: 
         genome = config['references']['GENOME'],
         ver_gatk=config['tools']['gatk4']['version'],
         rname = "mergegvcfs"
+    message: "Running GATK4 CombineGVCFs on '{input.gzvcf}' input file"
+    envmodules: 'GATK/4.2.0.0'
+    container: config['images']['wes_base'] 
     shell:
         """
         input_str="--variant $(echo "{input.gzvcf}" | sed -e 's/ / --variant /g')"
         
-        module load GATK/{params.ver_gatk}
-        gatk --java-options '-Xmx24g' CombineGVCFs --reference {params.genome} --annotation-group StandardAnnotation --annotation-group AS_StandardAnnotation $input_str --output {output.gzvcf} --intervals {wildcards.chroms} --use-jdk-inflater --use-jdk-deflater
+        gatk --java-options '-Xmx24g' CombineGVCFs \\
+            --reference {params.genome} \\
+            --annotation-group StandardAnnotation \\
+            --annotation-group AS_StandardAnnotation \\
+            $input_str \\
+            --output {output.gzvcf} \\
+            --intervals {wildcards.chroms} \\
+            --use-jdk-inflater \\
+            --use-jdk-deflater
         """
+
 
 rule genotype:
     """
@@ -70,21 +94,32 @@ rule genotype:
         index = os.path.join(output_germline_base,"gVCFs","merged.{chroms}.g.vcf.gz.tbi"),
     output:
         vcf = os.path.join(output_germline_base,"VCF","by_chrom","raw_variants.{chroms}.vcf.gz"),
-    # group: "merge_and_genotype"
     params:
         genome = config['references']['GENOME'],
         snpsites=config['references']['DBSNP'],
         chr="{chroms}",
         ver_gatk=config['tools']['gatk4']['version'],
         rname = "genotype"
+    message: "Running GATK4 GenotypeGVCFs on '{input.gzvcf}' input file"
+    envmodules: 'GATK/4.2.0.0'
+    container: config['images']['wes_base']
     shell:
         """
         myoutdir="$(dirname {output.vcf})"
         if [ ! -d "$myoutdir" ]; then mkdir -p "$myoutdir"; fi
         
-        module load GATK/{params.ver_gatk}
-        gatk --java-options '-Xmx96g' GenotypeGVCFs --reference {params.genome} --use-jdk-inflater --use-jdk-deflater --annotation-group StandardAnnotation --annotation-group AS_StandardAnnotation --dbsnp {params.snpsites} --output {output.vcf} --variant {input.gzvcf} --intervals {params.chr}
+        gatk --java-options '-Xmx96g' GenotypeGVCFs \\
+            --reference {params.genome} \\
+            --use-jdk-inflater \\
+            --use-jdk-deflater \\
+            --annotation-group StandardAnnotation \\
+            --annotation-group AS_StandardAnnotation \\
+            --dbsnp {params.snpsites} \\
+            --output {output.vcf} \\
+            --variant {input.gzvcf} \\
+            --intervals {params.chr}
         """
+
 
 rule germline_merge_chrom:
     """
@@ -98,15 +133,23 @@ rule germline_merge_chrom:
         expand(os.path.join(output_germline_base,"VCF","by_chrom","raw_variants.{chroms}.vcf.gz"), chroms=chroms),
     output:
         vcf = os.path.join(output_germline_base,"VCF","raw_variants.vcf.gz"),
-        list = os.path.join(output_germline_base,"VCF","by_chrom","raw_variants_byChrom.list"),
+        clist = os.path.join(output_germline_base,"VCF","by_chrom","raw_variants_byChrom.list"),
     params:
         rname = "merge_chrom", genome = config['references']['GENOME']
+    message: "Running GATK4 MergeVcfs on all chrom split VCF files"
+    envmodules: 'GATK/4.2.0.0'
+    container: config['images']['wes_base'] 
     shell:
         """
-        ls -d $(dirname "{output.list}")/raw_variants.*.vcf.gz > "{output.list}"
-        module load GATK/4.1.7.0
-        gatk MergeVcfs -R {params.genome} --INPUT="{output.list}" --OUTPUT={output.vcf}
+        # Avoids ARG_MAX issue which limits max length of a command
+        ls -d $(dirname "{output.clist}")/raw_variants.*.vcf.gz > "{output.clist}"
+
+        gatk MergeVcfs \\
+            -R {params.genome} \\
+            --INPUT="{output.clist}" \\
+            --OUTPUT={output.vcf}
         """
+
 
 rule Gatk_SelectVariants:
     """
@@ -116,11 +159,27 @@ rule Gatk_SelectVariants:
     @Output:
         Single-sample VCF with unfiltered germline variants
     """
-	input: vcf=os.path.join(output_germline_base,"VCF","raw_variants.vcf.gz"),
-	output: vcf=os.path.join(output_germline_base,"VCF","{samples}.germline.vcf.gz")
-	params: genome=config['references']['GENOME'], Sname = "{samples}", rname="varselect",ver_gatk=config['tools']['gatk4']['version'],targets=exome_targets_bed
-	shell:"""
-          module load GATK/{params.ver_gatk}
-          gatk SelectVariants -R {params.genome} --intervals {params.targets} --variant {input.vcf} --sample-name {params.Sname} --exclude-filtered --exclude-non-variants --output {output.vcf}
-	      """
-          
+    input: 
+        vcf = os.path.join(output_germline_base,"VCF","raw_variants.vcf.gz"),
+    output: 
+        vcf = os.path.join(output_germline_base,"VCF","{samples}.germline.vcf.gz")
+    params: 
+        genome=config['references']['GENOME'], 
+        Sname = "{samples}", 
+        rname="varselect",
+        ver_gatk=config['tools']['gatk4']['version'],
+        targets=exome_targets_bed
+    message: "Running GATK4 SelectVariants on '{input.vcf}' input file"
+    envmodules: 'GATK/4.2.0.0'
+    container: config['images']['wes_base']
+    shell:
+        """
+        gatk SelectVariants \\
+            -R {params.genome} \\
+            --intervals {params.targets} \\
+            --variant {input.vcf} \\
+            --sample-name {params.Sname} \\
+            --exclude-filtered \\
+            --exclude-non-variants \\
+            --output {output.vcf}
+        """

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -141,6 +141,7 @@ rule fastqc_bam:
         {input.bam} 
     """
 
+
 rule reformat_targets_bed:
     """
     Qualimap requires a 6-field BED file for coverage estimation.
@@ -224,8 +225,9 @@ rule samtools_flagstats:
     params: 
         rname = "samtools_flagstats"
     message: "Running SAMtools flagstat on '{input}' input file"
+    envmodules: 'samtools/1.12'
+    container: config['images']['wes_base']
     shell: """
-    module load samtools/1.12
     samtools flagstat {input.bam} > {output.txt}
     """
 
@@ -250,8 +252,9 @@ rule vcftools:
         prefix = os.path.join(output_qcdir,"raw_variants"),
         rname  = "vcftools",
     message: "Running VCFtools on '{input.vcf}' input file"
+    envmodules: 'vcftools/0.1.16'
+    container: config['images']['wes_base']
     shell: """
-    module load vcftools/0.1.16
     vcftools --gzvcf {input.vcf} --het --out {params.prefix}
     """
 
@@ -306,8 +309,10 @@ rule bcftools_stats:
         txt = os.path.join(output_qcdir,"{samples}.germline.bcftools_stats.txt"),
     params: 
         rname="bcfstats",
+    message: "Running BCFtools on '{input.vcf}' input file"
+    envmodules: 'bcftools/1.9'
+    container: config['images']['wes_base']
     shell: """
-    module load bcftools/1.9
     bcftools stats {input.vcf} > {output.txt}
     """
 
@@ -334,9 +339,11 @@ rule gatk_varianteval:
         genome   = config['references']['GENOME'],
         dbsnp    = config['references']['DBSNP'],
         ver_gatk = config['tools']['gatk4']['version']
+    message: "Running GATK4 VariantEval on '{input.vcf}' input file"
+    envmodules: 'GATK/4.2.0.0'
+    container: config['images']['wes_base']
     threads: 16
     shell: """
-    module load GATK/{params.ver_gatk}
     gatk --java-options '-Xmx12g -XX:ParallelGCThreads={threads}' VariantEval \\
         -R {params.genome} \\
         -O {output.grp} \\
@@ -375,6 +382,7 @@ rule snpeff:
         {params.genome} \\
         {input.vcf} > {output.vcf}
     """
+
 
 rule somalier_extract:
     """


### PR DESCRIPTION
## Changelog
- Removing bowtie exe path from fastq_screen config
- Converting germline rules to use docker images
- Adding tools WES Pipeline base image
  - Control-FREEC
  - Tabix
  - Sambamba
  - Sequenza
  - Somalier
  - VarScan
  - GATK/3.8 (CombineVariants step not available in GATK4)