### PR TITLE
Mutect/1.1.7 Dockerfile

### DIFF
--- a/docker/mutect/Dockerfile
+++ b/docker/mutect/Dockerfile
@@ -49,4 +49,6 @@ ENV MUTECT_JARPATH="/opt2/mirror-muTect-1.1.7"
 RUN ln -fs /usr/lib/jvm/java-7-openjdk-amd64/bin/java /usr/bin/java7
 
 # Reset working directory
+ADD Dockerfile /opt2/
+RUN chmod -R a+rwX /opt2
 WORKDIR /data2

--- a/docker/mutect/Dockerfile
+++ b/docker/mutect/Dockerfile
@@ -1,0 +1,52 @@
+# Base image
+# Installs muTect/1.17 and java7 (jdk 1.7)
+FROM ubuntu:14.04
+
+LABEL maintainer=kuhnsa@nih.gov
+
+# Create Container filesystem specific 
+# working directory and opt directories 
+RUN mkdir -p /opt2 && mkdir -p /data2
+WORKDIR /opt2 
+
+# Set time zone to US east coast 
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
+    && echo $TZ > /etc/timezone
+
+# This section installs system packages required for your project
+# If you need extra system packages add them here.
+# Strelka strictly requires python/2.7,
+# it is not compatiable with any other 
+# version of python.
+# Installs python/2.7.16
+RUN apt-get update \
+ && apt-get -y upgrade \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      build-essential \
+      bzip2 \
+      git \
+      locales \
+      openjdk-7-jdk \
+      software-properties-common \
+      unzip \
+      wget \
+ && apt-get clean && apt-get purge \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install MuTect/1.1.7, from my mirror with a pre-compiled JAR file
+# Requires java7 or jdk 1.7 for the pre-compiled JAR file (already satified)
+# openjdk-7-jdk not a part of ubuntu >= 18.04, so installation using 
+# an older LTS version of Ubunutu is required
+# Setting environment variables: MUTECT_JAR and MUTECT_JARPATH to 
+# mirror HPC module on Biowulf
+RUN git clone https://github.com/skchronicles/mirror-muTect-1.1.7.git
+ENV PATH="/opt2/mirror-muTect-1.1.7:$PATH"
+ENV MUTECT_JAR="/opt2/mirror-muTect-1.1.7/muTect-1.1.7.jar"
+ENV MUTECT_JARPATH="/opt2/mirror-muTect-1.1.7"
+
+# Make java8 (jdk 1.8 the default version)
+RUN ln -fs /usr/lib/jvm/java-7-openjdk-amd64/bin/java /usr/bin/java7
+
+# Reset working directory
+WORKDIR /data2

--- a/docker/mutect/build.sh
+++ b/docker/mutect/build.sh
@@ -1,0 +1,14 @@
+# Build image
+docker build -f Dockerfile --tag=ccbr_mutect:v0.1.0 .
+
+# Tag image with version and reset latest
+docker tag ccbr_mutect:v0.1.0 skchronicles/ccbr_mutect:v0.1.0
+docker tag ccbr_mutect:v0.1.0 skchronicles/ccbr_mutect
+docker tag ccbr_mutect:v0.1.0 nciccbr/ccbr_mutect:v0.1.0
+docker tag ccbr_mutect:v0.1.0 nciccbr/ccbr_mutect
+
+# Push image to DockerHub
+docker push skchronicles/ccbr_mutect:v0.1.0
+docker push skchronicles/ccbr_mutect:latest
+docker push nciccbr/ccbr_mutect:v0.1.0
+docker push nciccbr/ccbr_mutect:latest


### PR DESCRIPTION
# Changelog

The MuTect/1.1.7 pre-compiled JAR file is only compatible with a much older version of java (specifically java7 or jdk 1.7). This version of java is nearly impossible to download from any public facing link or package manager when using a newer LTS versions of Ubuntu (>= 18.04). 

### TLDR
- adding java7 (jdk 1.7) installation
- adding Dockerfile to build image for Mutect/1.1.7 JAR  