### PR TITLE
Updates and bug fixes

### DIFF
--- a/config/genomes/hg38.json
+++ b/config/genomes/hg38.json
@@ -6,6 +6,7 @@
 		"trimmomatic.adapters": "/data/CCBR_Pipeliner/db/PipeDB/dev/adapters2.fa",
 		"SNPEFF_GENOME": "GRCh38.86",
 		"SNPEFF_CONFIG": "/usr/local/apps/snpEff/4.3t/snpEff.config",
+		"SNPEFF_BUNDLE": "/fdb/snpEff/4.3t/data/",
 		"GENOME": "/data/tandonm/pl_test_data/human/genome/hg38/Homo_sapiens_assembly38.fasta",
 		"GENOMEDICT": "/data/tandonm/pl_test_data/human/genome/hg38/Homo_sapiens_assembly38.dict",
 		"DBSNP": "/fdb/GATK_resource_bundle/hg38bundle/dbsnp_138.hg38.vcf.gz",

--- a/config/genomes/hg38.json
+++ b/config/genomes/hg38.json
@@ -6,7 +6,7 @@
 		"trimmomatic.adapters": "/data/CCBR_Pipeliner/db/PipeDB/dev/adapters2.fa",
 		"SNPEFF_GENOME": "GRCh38.86",
 		"SNPEFF_CONFIG": "/usr/local/apps/snpEff/4.3t/snpEff.config",
-		"SNPEFF_BUNDLE": "/fdb/snpEff/4.3t/data/",
+		"SNPEFF_BUNDLE": "/fdb/snpEff/4.3t/",
 		"GENOME": "/data/tandonm/pl_test_data/human/genome/hg38/Homo_sapiens_assembly38.fasta",
 		"GENOMEDICT": "/data/tandonm/pl_test_data/human/genome/hg38/Homo_sapiens_assembly38.dict",
 		"DBSNP": "/fdb/GATK_resource_bundle/hg38bundle/dbsnp_138.hg38.vcf.gz",

--- a/docker/wes_base/Dockerfile
+++ b/docker/wes_base/Dockerfile
@@ -19,6 +19,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
 RUN apt-get update \
  && apt-get -y upgrade \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      bc \      
       build-essential \
       bzip2 \
       cmake \
@@ -149,7 +150,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD5
     && apt-get -y install libcurl4-openssl-dev libssl-dev libboost-dev libxml2-dev
 RUN Rscript -e 'install.packages(c("argparse", "knitr", "tidyverse", "dplyr", "plyr", "plotly", "ggplot2", "RColorBrewer", "htmlwidgets"), repos="http://cran.r-project.org")'
 RUN Rscript -e 'install.packages(c("shiny", "gridExtra", "flexdashboard", "rmarkdown", "crosstalk", "DT", "reshape2", "circlize", "viridis"), repos="http://cran.r-project.org")'
-RUN Rscript -e 'install.packages("BiocManager"); BiocManager::install(c("limma", "edgeR", "ComplexHeatmap"))'
+RUN Rscript -e 'install.packages("BiocManager"); BiocManager::install(c("limma", "edgeR", "ComplexHeatmap", "rtracklayer"))'
 
 # Install Control-FREEC/v11.6 and additional dependencies
 # Requires R, samtools, bedtools, sambamba (already satisfied)

--- a/docker/wes_base/Dockerfile
+++ b/docker/wes_base/Dockerfile
@@ -228,12 +228,18 @@ ENV PATH="/opt2/VarDict-1.8.2/bin:$PATH"
 
 # Add Dockerfile and argparse.bash script
 # and export environment variables
+# and creating a backwards compatible
+# wrapper for Biowulf's trimmomatic/0.39
 # and set java8 as default with links
 # to alternative versions
 ADD Dockerfile /opt2/base_gatk4_wes.dockerfile
 COPY argparse.bash /opt2
+ENV TRIMMOMATIC_JAR="/usr/share/java/trimmomatic-0.39.jar"
+RUN echo '#!/bin/bash' > /opt2/trimmomatic \
+    && echo 'java -jar "$TRIMMOMATIC_JAR" "$@"' >> /opt2/trimmomatic \
+    && chmod +x /opt2/trimmomatic
 RUN chmod -R a+rX /opt2 \
-    && chmod -R a+x /opt2/argparse.bash \
+    && chmod a+x /opt2/argparse.bash \
     && ln -s /usr/lib/jvm/java-11-openjdk-amd64/bin/java /usr/bin/java11 \
     && ln -s /usr/lib/jvm/java-8-openjdk-amd64/bin/java /usr/bin/java8 \
     && ln -fs /usr/lib/jvm/java-8-openjdk-amd64/bin/java /usr/bin/java

--- a/docker/wes_base/Dockerfile
+++ b/docker/wes_base/Dockerfile
@@ -251,5 +251,8 @@ ENV TRIMMOJAR="/usr/share/java/trimmomatic-0.39.jar"
 WORKDIR /data2
 
 # Clean-up step to reduce size
-RUN apt-get clean && apt-get purge && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Install GNU awk to calculate mean and standard deviation
+# Biowulf installation of awk is a pointer to gawk
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gawk \
+    && apt-get clean && apt-get purge \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/wes_base/Dockerfile
+++ b/docker/wes_base/Dockerfile
@@ -251,8 +251,12 @@ ENV TRIMMOJAR="/usr/share/java/trimmomatic-0.39.jar"
 WORKDIR /data2
 
 # Clean-up step to reduce size
-# Install GNU awk to calculate mean and standard deviation
-# Biowulf installation of awk is a pointer to gawk
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gawk \
+# and install GNU awk to calculate mean and standard 
+# deviation, ensures backward compatibility with 
+# biowulf installation of awk is a pointer to gawk,
+# and install pandoc (>= 1.12.3 required for Rmarkdown)    
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    gawk \
+    pandoc \
     && apt-get clean && apt-get purge \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/wes_base/Dockerfile
+++ b/docker/wes_base/Dockerfile
@@ -234,9 +234,10 @@ ENV PATH="/opt2/VarDict-1.8.2/bin:$PATH"
 # to alternative versions
 ADD Dockerfile /opt2/base_gatk4_wes.dockerfile
 COPY argparse.bash /opt2
+# Trimmomatic requires java11
 ENV TRIMMOMATIC_JAR="/usr/share/java/trimmomatic-0.39.jar"
 RUN echo '#!/bin/bash' > /opt2/trimmomatic \
-    && echo 'java -jar "$TRIMMOMATIC_JAR" "$@"' >> /opt2/trimmomatic \
+    && echo 'java11 -jar "$TRIMMOMATIC_JAR" "$@"' >> /opt2/trimmomatic \
     && chmod +x /opt2/trimmomatic
 RUN chmod -R a+rX /opt2 \
     && chmod a+x /opt2/argparse.bash \

--- a/workflow/rules/cnv.smk
+++ b/workflow/rules/cnv.smk
@@ -65,7 +65,7 @@ rule sequenza:
         tumorsample = "{samples}",
         gc = config['references']['SEQUENZAGC'],
         run_script = config['scripts']['run_sequenza'],
-        rname = "sequenza"
+        rname = 'sequenza'
     threads: 8
     envmodules:
         'sequenza-utils/2.2.0',
@@ -122,7 +122,7 @@ rule freec_exome_somatic_pass2:
         config_script = config['scripts']['freec_p2_config'],
         sig_script = config['scripts']['freec_significance'],
         plot_script = config['scripts']['freec_plot'],
-        rname = "pl:freec",
+        rname = 'freec',
     envmodules:
         'freec/11.5',
         'samtools/1.9',

--- a/workflow/rules/ffpe.smk
+++ b/workflow/rules/ffpe.smk
@@ -174,7 +174,7 @@ rule ffpefilter_mafs:
         tumorsample = '{samples}',
         genome = config['references']['MAF_GENOME'],
         filtervcf = config['references']['MAF_FILTERVCF'],
-        rname = 'pl:vcf2maf',
+        rname = 'vcf2maf',
         vcf2maf_script = VCF2MAF_WRAPPER
     shell: """
     echo "Converting to MAF..."

--- a/workflow/rules/ffpe.smk
+++ b/workflow/rules/ffpe.smk
@@ -176,9 +176,16 @@ rule ffpefilter_mafs:
         filtervcf = config['references']['MAF_FILTERVCF'],
         rname = 'vcf2maf',
         vcf2maf_script = VCF2MAF_WRAPPER
+    threads: 4
     shell: """
     echo "Converting to MAF..."
-    bash {params.vcf2maf_script} --vcf {input.filtered_vcf} --maf {output.maf} --tid {params.tumorsample} --genome {params.genome} --threads "$((SLURM_CPUS_PER_TASK-1))" --info "set"
+    bash {params.vcf2maf_script} \\
+        --vcf {input.filtered_vcf} \\
+        --maf {output.maf} \\
+        --tid {params.tumorsample} \\
+        --genome {params.genome} \\
+        --threads {threads} \\
+        --info "set"
     echo "Done converting to MAF..."
     """
 

--- a/workflow/rules/germline.smk
+++ b/workflow/rules/germline.smk
@@ -142,12 +142,12 @@ rule germline_merge_chrom:
     shell:
         """
         # Avoids ARG_MAX issue which limits max length of a command
-        ls -d $(dirname "{output.clist}")/raw_variants.*.vcf.gz > "{output.clist}"
+        ls --color=never -d $(dirname "{output.clist}")/raw_variants.*.vcf.gz > "{output.clist}"
 
         gatk MergeVcfs \\
             -R {params.genome} \\
-            --INPUT="{output.clist}" \\
-            --OUTPUT={output.vcf}
+            --INPUT {output.clist} \\
+            --OUTPUT {output.vcf}
         """
 
 

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -23,6 +23,10 @@ rule fc_lane:
     envmodules: 'python/2.7'
     container: config['images']['python']
     shell: """
+    if [ ! -d "$(dirname {output.txt})" ]; then 
+        mkdir -p "$(dirname {output.txt})"
+    fi
+    
     python {params.get_flowcell_lanes} \\
         {input.r1} \\
         {wildcards.samples} > {output.txt}

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -376,7 +376,8 @@ rule snpeff:
     params: 
         rname  = "snpeff",
         genome = config['references']['SNPEFF_GENOME'],
-        config = config['references']['SNPEFF_CONFIG']
+        config = config['references']['SNPEFF_CONFIG'],
+        bundle = config['references']['SNPEFF_BUNDLE'],
     envmodules: 'snpEff/4.3t'
     container: config['images']['wes_base']
     shell: """

--- a/workflow/rules/somatic_snps.common.smk
+++ b/workflow/rules/somatic_snps.common.smk
@@ -181,7 +181,7 @@ rule somatic_mafs:
         tumorsample = '{samples}',
         genome = config['references']['MAF_GENOME'],
         filtervcf = config['references']['MAF_FILTERVCF'],
-        rname = "pl:vcf2maf",
+        rname = 'vcf2maf',
         vcf2maf_script = VCF2MAF_WRAPPER
     shell: """
     echo "Converting to MAF..."

--- a/workflow/rules/somatic_snps.tumor_only.smk
+++ b/workflow/rules/somatic_snps.tumor_only.smk
@@ -99,8 +99,11 @@ rule mutect_single:
         ver_mutect = config['tools']['mutect']['version'],
         rname = 'mutect',
         tmpdir = '/lscratch/$SLURM_JOBID'
+    envmodules:
+        'muTect/1.1.7'
+    container:
+        config['images']['mutect']
     shell: """
-
     if [ ! -d "$(dirname {output.vcf})" ]; then 
         mkdir -p "$(dirname {output.vcf})"
     fi

--- a/workflow/rules/trim_map_preprocess.smk
+++ b/workflow/rules/trim_map_preprocess.smk
@@ -1,4 +1,4 @@
-
+# Rules for primary processing of raw data: trim, align, and recal
 rule bam2fastq:
     """
     Convert BAM files to paired FASTQ.
@@ -61,7 +61,7 @@ rule trimmomatic:
     params:
         adapterfile = config['references']['trimmomatic.adapters'],
         ver = config['tools']['trimmomatic']['version'],
-        rname = "pl:trimmomatic"
+        rname = 'trimmomatic'
     envmodules: 
         'trimmomatic/0.39'
     container:
@@ -101,7 +101,7 @@ rule bwa_mem:
         sample = "{samples}",
         ver_samtools = config['tools']['samtools']['version'],
         ver_bwa = config['tools']['bwa']['version'],
-        rname = "pl:bwamem"
+        rname = 'bwamem'
     envmodules: 
         'samtools/1.12'
         'bwa/0.7.17'
@@ -138,7 +138,7 @@ rule raw_index:
         bai = temp(os.path.join(output_bamdir,"preprocessing","{samples}.raw_map.bai")),
     params:
         ver_samtools = config['tools']['samtools']['version'],
-        rname = "raw_index"
+        rname = 'raw_index'
     envmodules: 
         'samtools/1.12'
     container: 
@@ -173,7 +173,7 @@ rule gatk_recal:
         ver_gatk = config['tools']['gatk4']['version'],
         chrom = chroms,
         intervals = intervals_file,
-        rname = "recal"
+        rname = 'recal'
     envmodules:
         'GATK/4.2.0.0'
     container:
@@ -217,7 +217,7 @@ rule bam_check:
     params:
         ver_samtools = config['tools']['samtools']['version'],
         ver_gatk = config['tools']['gatk4']['version'],
-        rname = "bam_check"
+        rname = 'bam_check'
     envmodules:
         'samtools/1.12',
         'GATK/4.2.0.0'

--- a/workflow/rules/trim_map_preprocess.smk
+++ b/workflow/rules/trim_map_preprocess.smk
@@ -56,8 +56,7 @@ rule trimmomatic:
         one = temp(os.path.join(output_fqdir, "{samples}.R1.trimmed.fastq.gz")),
         two = temp(os.path.join(output_fqdir, "{samples}.R1.trimmed.unpair.fastq.gz")),
         three = temp(os.path.join(output_fqdir, "{samples}.R2.trimmed.fastq.gz")),
-        four = temp(os.path.join(output_fqdir, "{samples}.R2.trimmed.unpair.fastq.gz")),
-        err = os.path.join(output_fqdir, "{samples}_run_trimmomatic.err")
+        four = temp(os.path.join(output_fqdir, "{samples}.R2.trimmed.unpair.fastq.gz"))
     params:
         adapterfile = config['references']['trimmomatic.adapters'],
         ver = config['tools']['trimmomatic']['version'],
@@ -79,7 +78,7 @@ rule trimmomatic:
         LEADING:10 \\
         TRAILING:10 \\
         SLIDINGWINDOW:4:20 \\
-        MINLEN:20 2> {output.err}     
+        MINLEN:20      
     """
 
 


### PR DESCRIPTION
# Changelog
 - Updating job names of each rule to remove lingering `pl:` prefix 
 - Adding trimmomatic wrapper using java11 (jdk 1.11) to WES base image for backward compatibility with Biowulf
 - Fix: creating uninitialized output directory in rule fc_lane
 - Updating gatk MergeVcfs usage due to incompatibility with GATK/4.2.X
 - Adding bc for math operations to WES base image
 - Adding mutect image to TN rules 
 - Adding path to snpEff bundle to ensure bind path of singularity is mounted
 - Adding gawk to WES base image to ensure backwards compatibility with Biowulf
 - Adding missing pandoc/2.5 dependency for Rmarkdown to WES base image