### PR TITLE
vcf2maf: VEP release 102 changes

### DIFF
--- a/config/containers/images.json
+++ b/config/containers/images.json
@@ -1,7 +1,7 @@
 {
     "images": {
         "wes_base": "docker://nciccbr/ccbr_wes_base:v0.1.0",
-        "vcf2maf": "docker://nciccbr/ccbr_vcf2maf:v0.1.1",
+        "vcf2maf": "docker://nciccbr/ccbr_vcf2maf:v102.0.0",
         "mutect": "docker://nciccbr/ccbr_mutect:v0.1.0",
         "fastq_screen": "docker://nciccbr/ccbr_fastq_screen_0.13.0:v2.0",
         "fastqc": "docker://nciccbr/ccbr_fastqc_0.11.9:v1.1",

--- a/docker/vcf2maf/Dockerfile
+++ b/docker/vcf2maf/Dockerfile
@@ -1,0 +1,89 @@
+# Base image: VEP release 102 from Ensembl
+# hub.docker.com/r/ensemblorg/ensembl-vep/tags
+# VEP release 102 matches GENCODE v36 for GRCh38
+# This GENCODE release matches the upcoming major
+# relase to GDC GENCODE gene reference model.
+# The GDC will be replacing the files in the 
+# GDC data portal that were generated using 
+# GENCODE v22 with files that were generated 
+# using GENCODE v36. GDC will release the
+# reprocessed data on 11/30/2021.
+# @ubuntu/18.04
+# @Dockerfile: 
+# github.com/Ensembl/ensembl-vep/blob/release/102/docker/Dockerfile
+FROM ensemblorg/ensembl-vep:release_102.0
+
+LABEL maintainer=kuhnsa@nih.gov
+
+# Create Container filesystem specific 
+# working directory and opt directories
+USER root
+RUN mkdir -p /opt2 && mkdir -p /data2
+WORKDIR /opt2 
+
+# Set time zone to US east coast 
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
+    && echo $TZ > /etc/timezone
+
+# This section installs system 
+# packages required for your 
+# project. If you need extra 
+# system packages add them here.
+# argparse.bash requires argparse
+# python package.
+# Installs python/3.6, which
+# includes argparse by default
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        build-essential \
+        libncurses5-dev \
+        libncursesw5-dev \
+        libssl-dev \
+        libcurl4-gnutls-dev \
+        liblzma-dev \
+        libbz2-dev \
+        python3 \
+        python3-pip \
+        wget \
+        zlib1g-dev \
+    && apt-get clean && apt-get purge \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install htslib/1.10
+RUN wget https://github.com/samtools/htslib/releases/download/1.10/htslib-1.10.tar.bz2 \
+        && tar -vxjf htslib-1.10.tar.bz2 \
+        && rm htslib-1.10.tar.bz2 \
+        && cd htslib-1.10 \
+        && make \
+        && cd /opt2
+
+# Install samtools/1.10
+RUN wget https://github.com/samtools/samtools/releases/download/1.10/samtools-1.10.tar.bz2 \
+        && tar -vxjf samtools-1.10.tar.bz2 \
+        && rm samtools-1.10.tar.bz2 \
+        && cd samtools-1.10 \
+        && make \
+        && cd /opt2
+
+# Install bcftools/1.10
+RUN wget https://github.com/samtools/bcftools/releases/download/1.10/bcftools-1.10.tar.bz2 \
+        && tar -vxjf bcftools-1.10.tar.bz2 \
+        && rm bcftools-1.10.tar.bz2 \
+        && cd bcftools-1.10 \
+        && make \
+        && cd /opt2
+
+# Add Dockerfile and argparse.bash script
+# and export environment variables
+# and ensure proper permissions
+ADD Dockerfile /opt2/Dockerfile
+COPY argparse.bash /opt2
+RUN chmod -R a+rX /opt2 \
+    && chmod a+x /opt2/argparse.bash \
+    && ln -sf /usr/bin/python3 /usr/bin/python
+ENV PATH="$PATH:/opt2/bcftools-1.10:/opt2/samtools-1.10:/opt2/htslib-1.10:/opt2"
+
+# Reset working directory
+WORKDIR /data2

--- a/docker/vcf2maf/Dockerfile
+++ b/docker/vcf2maf/Dockerfile
@@ -75,6 +75,12 @@ RUN wget https://github.com/samtools/bcftools/releases/download/1.10/bcftools-1.
         && make \
         && cd /opt2
 
+# Install vcf2maf/v1.6.17
+RUN wget https://github.com/mskcc/vcf2maf/archive/refs/tags/v1.6.17.tar.gz \
+        && tar -xvf v1.6.17.tar.gz \
+        && rm v1.6.17.tar.gz \
+        && chmod a+rx /opt2/vcf2maf-1.6.17/*.pl
+
 # Add Dockerfile and argparse.bash script
 # and export environment variables
 # and ensure proper permissions
@@ -83,7 +89,7 @@ COPY argparse.bash /opt2
 RUN chmod -R a+rX /opt2 \
     && chmod a+x /opt2/argparse.bash \
     && ln -sf /usr/bin/python3 /usr/bin/python
-ENV PATH="$PATH:/opt2/bcftools-1.10:/opt2/samtools-1.10:/opt2/htslib-1.10:/opt2"
+ENV PATH="$PATH:/opt2/bcftools-1.10:/opt2/samtools-1.10:/opt2/htslib-1.10:/opt2:/opt2/vcf2maf-1.6.17"
 
 # Reset working directory
 WORKDIR /data2

--- a/docker/vcf2maf/argparse.bash
+++ b/docker/vcf2maf/argparse.bash
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Use python's argparse module in shell scripts
+#
+# The function `argparse` parses its arguments using
+# argparse.ArgumentParser; the parser is defined in the function's
+# stdin.
+#
+# Executing ``argparse.bash`` (as opposed to sourcing it) prints a
+# script template.
+#
+# https://github.com/nhoffman/argparse-bash
+# MIT License - Copyright (c) 2015 Noah Hoffman
+
+argparse(){
+    argparser=$(mktemp 2>/dev/null || mktemp -t argparser)
+    cat > "$argparser" <<EOF
+from __future__ import print_function
+import sys
+import argparse
+import os
+class MyArgumentParser(argparse.ArgumentParser):
+    def print_help(self, file=None):
+        """Print help and exit with error"""
+        super(MyArgumentParser, self).print_help(file=file)
+        sys.exit(1)
+parser = MyArgumentParser(prog=os.path.basename("$0"),
+            description="""$ARGPARSE_DESCRIPTION""")
+EOF
+
+    # stdin to this function should contain the parser definition
+    cat >> "$argparser"
+
+    cat >> "$argparser" <<EOF
+args = parser.parse_args()
+for arg in [a for a in dir(args) if not a.startswith('_')]:
+    key = arg.upper()
+    value = getattr(args, arg, None)
+    if isinstance(value, bool) or value is None:
+        print('{0}="{1}";'.format(key, 'yes' if value else ''))
+    elif isinstance(value, list):
+        print('{0}=({1});'.format(key, ' '.join('"{0}"'.format(s) for s in value)))
+    else:
+        print('{0}="{1}";'.format(key, value))
+EOF
+
+    # Define variables corresponding to the options if the args can be
+    # parsed without errors; otherwise, print the text of the error
+    # message.
+    if python "$argparser" "$@" &> /dev/null; then
+        eval $(python "$argparser" "$@")
+        retval=0
+    else
+        python "$argparser" "$@"
+        retval=1
+    fi
+
+    rm "$argparser"
+    return $retval
+}
+
+# print a script template when this script is executed
+if [[ $0 == *argparse.bash ]]; then
+    cat <<FOO
+#!/usr/bin/env bash
+source \$(dirname \$0)/argparse.bash || exit 1
+argparse "\$@" <<EOF || exit 1
+parser.add_argument('infile')
+parser.add_argument('-o', '--outfile')
+EOF
+echo "INFILE: \${INFILE}"
+echo "OUTFILE: \${OUTFILE}"
+FOO
+fi

--- a/docker/vcf2maf/build.sh
+++ b/docker/vcf2maf/build.sh
@@ -1,0 +1,14 @@
+# Build image
+docker build -f Dockerfile --tag=ccbr_vcf2maf:v102.0.0 .
+
+# Tag image with version and reset latest
+docker tag ccbr_vcf2maf:v102.0.0 skchronicles/ccbr_vcf2maf:v102.0.0
+docker tag ccbr_vcf2maf:v102.0.0 skchronicles/ccbr_vcf2maf
+docker tag ccbr_vcf2maf:v102.0.0 nciccbr/ccbr_vcf2maf:v102.0.0
+docker tag ccbr_vcf2maf:v102.0.0 nciccbr/ccbr_vcf2maf
+
+# Push image to DockerHub
+docker push skchronicles/ccbr_vcf2maf:v102.0.0
+docker push skchronicles/ccbr_vcf2maf:latest
+docker push nciccbr/ccbr_vcf2maf:v102.0.0
+docker push nciccbr/ccbr_vcf2maf:latest

--- a/workflow/rules/ffpe.smk
+++ b/workflow/rules/ffpe.smk
@@ -221,6 +221,7 @@ rule ffpefilter_mafs:
         tumorsample = '{samples}',
         genome = config['references']['MAF_GENOME'],
         filtervcf = config['references']['MAF_FILTERVCF'],
+        bundle = config['references']['VCF2MAF']['VEPRESOURCEBUNDLEPATH'],
         rname = 'vcf2maf',
         vcf2maf_script = VCF2MAF_WRAPPER
     threads: 4
@@ -234,6 +235,7 @@ rule ffpefilter_mafs:
         --tid {params.tumorsample} \\
         --genome {params.genome} \\
         --threads {threads} \\
+        --vepresourcebundlepath {params.bundle} \\
         --info "set"
     echo "Done converting to MAF..."
     """

--- a/workflow/rules/somatic_snps.common.smk
+++ b/workflow/rules/somatic_snps.common.smk
@@ -181,6 +181,7 @@ rule somatic_mafs:
         tumorsample = '{samples}',
         genome = config['references']['MAF_GENOME'],
         filtervcf = config['references']['MAF_FILTERVCF'],
+        bundle = config['references']['VCF2MAF']['VEPRESOURCEBUNDLEPATH'],
         rname = 'vcf2maf',
         vcf2maf_script = VCF2MAF_WRAPPER
     threads: 4
@@ -194,6 +195,7 @@ rule somatic_mafs:
         --tid {params.tumorsample} \\
         --genome {params.genome} \\
         --threads {threads} \\
+        --vepresourcebundlepath {params.bundle} \\
         --info "set"
     echo "Done converting to MAF..."
     """

--- a/workflow/scripts/vcf2maf_wrapper.bash
+++ b/workflow/scripts/vcf2maf_wrapper.bash
@@ -3,9 +3,6 @@ set -e -o pipefail
 
 # Source argparse bash wrapper for more
 # advanced argument parsing in bash
-. /opt2/conda/etc/profile.d/conda.sh && \
-  conda activate python2
-
 source /opt2/argparse.bash \
         || exit 1
 


### PR DESCRIPTION
## Why?
VEP release 102 matches GENCODE v36 for GRCh38. This GENCODE release matches the upcoming major release to GDC GENCODE gene reference model. The GDC will be replacing the files in the  GDC data portal that were generated using GENCODE v22 with files that were generated using GENCODE v36. GDC will release the reprocessed data on 11/30/2021.

## Changelog
- Adding Dockerfile for new vcf2maf image using VEP release and resource bundle 102
- Updating rules and vcf2maf wrapper script 
