### PR TITLE
May the FRCE be with you

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Welcome to exome-seek! Before getting started, we highly recommend reading throu
 
 The **`./exome-seek`** pipeline is composed several inter-related sub commands to setup and run the pipeline across different systems. Each of the available sub commands perform different functions: 
 
- * [<code>exome-seek <b>run</b></code>](usage/run.md): Run the GATK4 WES pipeline with your input files.
- * [<code>exome-seek <b>unlock</b></code>](usage/unlock.md): Unlocks a previous runs output directory.
- * [<code>exome-seek <b>cache</b></code>](usage/cache.md): Cache remote resources locally, coming soon!
+ * [<code>exome-seek <b>run</b></code>](https://mtandon09.github.io/CCBR_GATK4_Exome_Seq_Pipeline/usage/run/): Run the GATK4 WES pipeline with your input files.
+ * [<code>exome-seek <b>unlock</b></code>](https://mtandon09.github.io/CCBR_GATK4_Exome_Seq_Pipeline/usage/unlock/): Unlocks a previous runs output directory.
+ * [<code>exome-seek <b>cache</b></code>](https://mtandon09.github.io/CCBR_GATK4_Exome_Seq_Pipeline/usage/cache/): Cache remote resources locally, coming soon!
 
 Exome-seek is a comprehensive whole exome-sequencing pipeline following the Broad's set of best practices. It relies on technologies like [Singularity<sup>1</sup>](https://singularity.lbl.gov/) to maintain the highest-level of reproducibility. The pipeline consists of a series of data processing and quality-control steps orchestrated by [Snakemake<sup>2</sup>](https://snakemake.readthedocs.io/en/stable/), a flexible and scalable workflow management system, to submit jobs to a cluster or cloud provider.
 

--- a/exome-seek
+++ b/exome-seek
@@ -125,7 +125,8 @@ def run(sub_args):
         jobname = sub_args.job_name,
         submission_script='runner',
         logger = logfh,
-        additional_bind_paths = ",".join(bindpaths)
+        additional_bind_paths = ",".join(bindpaths),
+        tmp_dir = sub_args.tmp_dir, 
     )
     
     # Step 5. Wait for subprocess to complete,
@@ -279,6 +280,7 @@ def parsed_arguments():
                               [--silent] \\
                               [--singularity-cache SINGULARITY_CACHE] \\
                               [--sif-cache SIF_CACHE] \\
+                              [--tmpdir TMP_DIR] \\
                               [--threads THREADS] \\
                               --input INPUT [INPUT ...] \\
                               --output OUTPUT \\
@@ -497,6 +499,25 @@ def parsed_arguments():
         the image will be pulled from Dockerhub. The exome-seek cache \
         subcommand can be used to create a local SIF cache. Please see \
         exome-seek cache for more information.'
+    )
+
+    # Base directory to write temporary files 
+    subparser_run.add_argument('--tmp-dir',
+        type = str,
+        required = False,
+        default = '/lscratch/$SLURM_JOBID/',
+        help = 'Path on the filesystem for writing intermediate, temporary output \
+        files. By default, this variable is set to \'/lscratch/$SLURM_JOBID\' \
+        for backwards compatibility with the NIH\'s Biowulf cluster; however, \
+        if you are running the pipeline on another cluster, this option will \
+        need to be specified. Ideally, this path should point to a dedicated \
+        location on the filesystem for writing tmp files. On many systems, this \
+        location is set to somewhere in /scratch. If you need to inject a variable \
+        into this string that should NOT be expanded, please quote this options \
+        value in single quotes. As an example, on the NCI/NIH FRCE cluster the \
+        value of this option would be set to \
+        --tmp-dir \'/scratch/cluster_scratch/${USER}/\', \
+        default:  \'/lscratch/$SLURM_JOBID/\''
     )
 
     # Number of threads for the exome-seek pipeline's main proceess

--- a/resources/runner
+++ b/resources/runner
@@ -212,8 +212,8 @@ function submit(){
           # what GRES is and how or why
           # it should be used and by default
           # SLURM is not configured to use 
-          # GRES
-          if [[ $6 == /lscracth* ]]; then
+          # GRES, remove prefix single quote
+          if [[ ${6#\'} == /lscratch* ]]; then
             CLUSTER_OPTS="sbatch --cpus-per-task {cluster.threads} -p {cluster.partition} -t {cluster.time} --mem {cluster.mem} --job-name={params.rname} -e $SLURM_DIR/slurm-%j_{params.rname}.out -o $SLURM_DIR/slurm-%j_{params.rname}.out"
           fi
           # Create sbacth script to build index

--- a/resources/runner
+++ b/resources/runner
@@ -213,7 +213,7 @@ function submit(){
           # it should be used and by default
           # SLURM is not configured to use 
           # GRES, remove prefix single quote
-          if [[ ${6#\'} == /lscratch* ]]; then
+          if [[ ${6#\'} != /lscratch* ]]; then
             CLUSTER_OPTS="sbatch --cpus-per-task {cluster.threads} -p {cluster.partition} -t {cluster.time} --mem {cluster.mem} --job-name={params.rname} -e $SLURM_DIR/slurm-%j_{params.rname}.out -o $SLURM_DIR/slurm-%j_{params.rname}.out"
           fi
           # Create sbacth script to build index

--- a/resources/runner
+++ b/resources/runner
@@ -8,7 +8,8 @@ USAGE:
   runner <MODE> [-h] [-c CACHE] \\
           -o OUTDIR \\
           -j MASTER_JOB_NAME \\
-          -b SINGULARITY_BIND_PATHS
+          -b SINGULARITY_BIND_PATHS \\
+          -t TMP_DIR
 
 SYNOPSIS:
   This script creates/submits the pipeline's master job  to  the 
@@ -42,7 +43,7 @@ Required Arguments:
                                  where all output files will be generated.
   -j, --job-name [Type: Str]    Name of pipeline's master job.
   -b, --bind-paths [Type:Path]  Singularity bind paths. The pipeline uses
-                                 singaularity images for exection. Bind 
+                                 singularity images for exection. Bind 
                                  paths are used to mount the host file 
                                  system to the container's file system. 
                                  Multiple bind paths can be provided as 
@@ -57,6 +58,13 @@ Required Arguments:
                                  output directory and any directories for 
                                  reference files. Please see example usage
                                  below.
+ -t, --tmp-dir [Type:Path]      Temporary directory. The pipeline generates
+                                 intermediate, temporary output files. Any 
+                                 temporary output files will be written to
+                                 this location. On Biowulf, it should be 
+                                 set to '/lscratch/\$SLURM_JOBID/'. On FRCE,
+                                 this value should be set to the following: 
+                                 '/scratch/cluster_scratch/\${USER}/'.     
 
 OPTIONS:
   -c,  --cache  [Type: Path]   Path to singularity cache. If not provided, 
@@ -92,8 +100,10 @@ function parser() {
       -h  | --help) usage && exit 0;;
       -j  | --job-name)   provided "$key" "${2:-}"; Arguments["j"]="$2"; shift; shift;;
       -b  | --bind-paths) provided "$key" "${2:-}"; Arguments["b"]="$2"; shift; shift;;
+      -t  | --tmp-dir) provided "$key" "${2:-}"; Arguments["t"]="$2"; shift; shift;;
       -o  | --outdir)  provided "$key" "${2:-}"; Arguments["o"]="$2"; shift; shift;;
       -c  | --cache)  provided "$key" "${2:-}"; Arguments["c"]="$2"; shift; shift;;
+
       -*  | --*) err "Error: Failed to parse unsupported argument: '${key}'."; usage && exit 1;;
       *) err "Error: Failed to parse unrecognized argument: '${key}'. Do any of your inputs have spaces?"; usage && exit 1;;
     esac
@@ -155,6 +165,7 @@ function submit(){
   # INPUT $3 = Pipeline output directory
   # INPUT $4 = Singularity Bind paths
   # INPUT $5 = Singularity cache directory
+  # INPUT $6 = Temporary directory for output files
 
   # Check if singularity and snakemake are in $PATH
   # If not, try to module load singularity as a last resort
@@ -189,6 +200,22 @@ function submit(){
           # --singularity-args -B {}.format({bindpaths}) --local-cores 24
           SLURM_DIR="$3/logfiles/slurmfiles"
           CLUSTER_OPTS="sbatch --gres {cluster.gres} --cpus-per-task {cluster.threads} -p {cluster.partition} -t {cluster.time} --mem {cluster.mem} --job-name={params.rname} -e $SLURM_DIR/slurm-%j_{params.rname}.out -o $SLURM_DIR/slurm-%j_{params.rname}.out"
+          # Check if NOT running on Biowulf
+          # Assumes other clusters do NOT 
+          # have GRES for local node disk,
+          # long term it might be worth 
+          # adding a new option to allow 
+          # a user to decide whether to 
+          # use GRES at job submission,
+          # trying to infer this because
+          # most users will not even know
+          # what GRES is and how or why
+          # it should be used and by default
+          # SLURM is not configured to use 
+          # GRES
+          if [[ $6 == /lscracth* ]]; then
+            CLUSTER_OPTS="sbatch --cpus-per-task {cluster.threads} -p {cluster.partition} -t {cluster.time} --mem {cluster.mem} --job-name={params.rname} -e $SLURM_DIR/slurm-%j_{params.rname}.out -o $SLURM_DIR/slurm-%j_{params.rname}.out"
+          fi
           # Create sbacth script to build index
     cat << EOF > kickoff.sh
 #!/usr/bin/env bash
@@ -260,7 +287,7 @@ function main(){
 
   # Run pipeline and submit jobs to cluster using the defined executor
   mkdir -p "${Arguments[o]}/logfiles/"
-  job_id=$(submit "${Arguments[e]}" "${Arguments[j]}" "${Arguments[o]}" "${Arguments[b]}" "${Arguments[c]}")
+  job_id=$(submit "${Arguments[e]}" "${Arguments[j]}" "${Arguments[o]}" "${Arguments[b]}" "${Arguments[c]}" "${Arguments[t]}")
   echo -e "exome-seek pipeline submitted to cluster.\nMaster Job ID: $job_id"
   echo "${job_id}" > "${Arguments[o]}/logfiles/mjobid.log"
 

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -101,11 +101,16 @@ rule kraken:
     container: config['images']['kraken']
     threads: 24
     shell: """
+    # Setups temporary directory for
+    # intermediate files with built-in 
+    # mechanism for deletion on exit
+    tmp=$(mktemp -d -p "{params.localdisk}")
+    trap 'rm -rf "${{tmp}}"' EXIT
+
     # Copy kraken2 db to local node storage to reduce filesystem strain
-    mkdir -p {params.localdisk}
-    cp -rv {params.bacdb} {params.localdisk}
+    cp -rv {params.bacdb} ${{tmp}}
     kdb_base=$(basename {params.bacdb})
-    kraken2 --db {params.localdisk}/${{kdb_base}} \\
+    kraken2 --db ${{tmp}}/${{kdb_base}} \\
         --threads {threads} --report {output.taxa} \\
         --output {output.out} \\
         --gzip-compressed \\

--- a/workflow/rules/somatic_snps.tumor_only.smk
+++ b/workflow/rules/somatic_snps.tumor_only.smk
@@ -48,13 +48,19 @@ rule pileup_single:
         ver_gatk = config['tools']['gatk4']['version'],
         chroms = chroms,
         rname = 'pileup',
-        tmpdir = '/lscratch/$SLURM_JOBID'
+        tmpdir = config['input_params']['tmpdisk']
     envmodules:
         'GATK/4.2.0.0'
     container:
         config['images']['wes_base']
     shell: """
-    gatk --java-options "-Xmx10g -Djava.io.tmpdir={params.tmpdir}" GetPileupSummaries \\
+    # Setups temporary directory for
+    # intermediate files with built-in 
+    # mechanism for deletion on exit
+    tmp=$(mktemp -d -p "{params.tmpdir}")
+    trap 'rm -rf "${{tmp}}"' EXIT
+
+    gatk --java-options "-Xmx10g -Djava.io.tmpdir=${{tmp}}" GetPileupSummaries \\
         -R {params.genome} \\
         -I {input.tumor} \\
         -V {params.germsource} \\
@@ -98,17 +104,23 @@ rule mutect_single:
         dbsnp = config['references']['DBSNP'],
         ver_mutect = config['tools']['mutect']['version'],
         rname = 'mutect',
-        tmpdir = '/lscratch/$SLURM_JOBID'
+        tmpdir = config['input_params']['tmpdisk']
     envmodules:
         'muTect/1.1.7'
     container:
         config['images']['mutect']
     shell: """
+    # Setups temporary directory for
+    # intermediate files with built-in 
+    # mechanism for deletion on exit
+    tmp=$(mktemp -d -p "{params.tmpdir}")
+    trap 'rm -rf "${{tmp}}"' EXIT
+
     if [ ! -d "$(dirname {output.vcf})" ]; then 
         mkdir -p "$(dirname {output.vcf})"
     fi
 
-    java -Xmx8g -Djava.io.tmpdir={params.tmpdir} -jar ${{MUTECT_JAR}} \\
+    java -Xmx8g -Djava.io.tmpdir=${{tmp}} -jar ${{MUTECT_JAR}} \\
         --analysis_type MuTect \\
         --reference_sequence {params.genome} \\
         --normal_panel {params.pon} \\
@@ -135,7 +147,7 @@ rule mutect_filter_single:
         ver_gatk = config['tools']['gatk4']['version'],
         ver_bcftools = config['tools']['bcftools']['version'],
         rname = 'mutect_filter',
-        tmpdir = '/lscratch/$SLURM_JOBID',
+        tmpdir = config['input_params']['tmpdisk'],
     threads: 4
     envmodules:
         'GATK/4.2.0.0',
@@ -143,6 +155,12 @@ rule mutect_filter_single:
     container:
         config['images']['wes_base']
     shell: """
+    # Setups temporary directory for
+    # intermediate files with built-in 
+    # mechanism for deletion on exit
+    tmp=$(mktemp -d -p "{params.tmpdir}")
+    trap 'rm -rf "${{tmp}}"' EXIT
+
     gatk SelectVariants \\
         -R {params.genome} \\
         --variant {input.vcf} \\
@@ -152,7 +170,7 @@ rule mutect_filter_single:
     # VarScan can output ambiguous IUPAC bases/codes
     # the awk one-liner resets them to N, from:
     # https://github.com/fpbarthel/GLASS/issues/23
-    bcftools sort -T {params.tmpdir} "{output.final}" \\
+    bcftools sort -T ${{tmp}} "{output.final}" \\
         | bcftools norm --threads {threads} --check-ref s -f {params.genome} -O v \\
         | awk '{{gsub(/\y[W|K|Y|R|S|M]\y/,"N",$4); OFS = "\t"; print}}' \\
         | sed '/^$/d' > {output.norm}
@@ -217,7 +235,7 @@ rule vardict_filter_single:
         ver_gatk = config['tools']['gatk4']['version'],
         ver_bcftools = config['tools']['bcftools']['version'],
         rname = 'vardict_filter', 
-        tmpdir = '/lscratch/$SLURM_JOBID'
+        tmpdir = config['input_params']['tmpdisk']
     threads: 4
     envmodules:
         'bcftools/1.9',
@@ -225,6 +243,12 @@ rule vardict_filter_single:
     container:
         config['images']['wes_base']
     shell: """
+    # Setups temporary directory for
+    # intermediate files with built-in 
+    # mechanism for deletion on exit
+    tmp=$(mktemp -d -p "{params.tmpdir}")
+    trap 'rm -rf "${{tmp}}"' EXIT
+
     gatk SelectVariants \\
         -R {params.genome} \\
         --variant {input.vcf} \\
@@ -235,7 +259,7 @@ rule vardict_filter_single:
     # VarScan can output ambiguous IUPAC bases/codes
     # the awk one-liner resets them to N, from:
     # https://github.com/fpbarthel/GLASS/issues/23
-    bcftools sort -T {params.tmpdir} "{output.final}" \\
+    bcftools sort -T ${{tmp}} "{output.final}" \\
         | bcftools norm --threads {threads} --check-ref s -f {params.genome} -O v \\
         | awk '{{gsub(/\y[W|K|Y|R|S|M]\y/,"N",$4); OFS = "\t"; print}}' \\
         | sed '/^$/d' > {output.norm}
@@ -290,7 +314,7 @@ rule varscan_filter_single:
         ver_varscan = config['tools']['varscan']['version'],
         ver_bcftools = config['tools']['bcftools']['version'],
         rname = 'varscan_filter',
-        tmpdir = '/lscratch/$SLURM_JOBID',
+        tmpdir = config['input_params']['tmpdisk'],
     threads: 4
     envmodules:
         'VarScan/2.4.3',
@@ -299,6 +323,12 @@ rule varscan_filter_single:
     container:
         config['images']['wes_base']
     shell: """
+    # Setups temporary directory for
+    # intermediate files with built-in 
+    # mechanism for deletion on exit
+    tmp=$(mktemp -d -p "{params.tmpdir}")
+    trap 'rm -rf "${{tmp}}"' EXIT
+
     varscan filter \\
         {input.vcf} \\
         {params.filter_settings} > {output.filtered1}
@@ -321,7 +351,7 @@ rule varscan_filter_single:
     # VarScan can output ambiguous IUPAC bases/codes
     # the awk one-liner resets them to N, from:
     # https://github.com/fpbarthel/GLASS/issues/23
-    bcftools sort -T {params.tmpdir} "{output.final}" \\
+    bcftools sort -T ${{tmp}} "{output.final}" \\
         | bcftools norm --threads {threads} --check-ref s -f {params.genome} -O v \\
         | awk '{{gsub(/\y[W|K|Y|R|S|M]\y/,"N",$4); OFS = "\t"; print}}' \\
         | sed '/^$/d' > {output.norm}


### PR DESCRIPTION
## Changelog

**Overview**
Most clusters have a dedicated space for writing temporary files on the filesystem. Each node on FRCE has local, physical disk that does not need to be allocated up front by the job scheduler to be obtained. On Biowulf, you need to allocate X GB of local disk before you can use it. With that being said, FRCE also has NFS `/scratch` disk for each user. It is recommended to use this instead of the local node storage, as local node storage is a free for all, and IT IS NOT CLEANED UP AFTER EACH JOB COMPLETES :vomiting_face:. 

This could become problematic to say the least, as one user could theoretically fill up the disk and cause other running jobs (or subsequent jobs scheduled to that node) to fail. As so, it is important to delete the tmp_dir after the job has exited. I have added a trap statement to do this on exit so it will delete the tmp_dir when a job complete or fails or even if the job unexpectedly ends. This is super important. If it is not done, you could cause other people's jobs to fail. 

**TLDR**
These updates to ensure interoperability between the NIH's Biowulf cluster and the NCI's FRCE cluster. The FRCE cluster does not rely on [SLURM's Generic Resource (GRES) Scheduling](https://slurm.schedmd.com/gres.html) to allocate local node storage. 

This PR ensures the following:
 1. A user can define a tmp dir to write temporary, intermediate files up front.
 2. If the tmp dir is in `/lscratch`, then it is assumed the user is running the pipeline on Biowulf and GRES will be provided to child jobs for local node disk space.
 3. The tmp dir is cleaned up after a job exits. This ensures there will be no issues when running the pipeline on FRCE cluster.
