### PR TITLE
Patch: BCF tools in SOB Detection rule

### DIFF
--- a/workflow/rules/ffpe.smk
+++ b/workflow/rules/ffpe.smk
@@ -138,7 +138,6 @@ rule sobdetect_pass2:
         # File contains no variants, catch
         # problem so pipeline can continue
         cat "{input.vcf}" > {output.pass2_vcf}
-        bcf_annotate_option=""
     else
         # SOB Dectector failed for another reason
         echo "SOB Detector Failed... exiting now!" 1>&2


### PR DESCRIPTION
The following BCF tool sub commands (annotate and filter) work fine when given a empty VCF file (i.e. an input file only containing a VCF header). With that being said, there is no need to reset the `$bcf_annotate_option` an empty string. This only causes issues later on when BCF tools is parsing command line arguments. It interprets an empty string as a file with its input name being an empty string:
![image](https://user-images.githubusercontent.com/18038345/150017786-52c1de27-5f1f-44c7-ae9c-9f47eda97206.png)

As so, BCF tools will work with bcf_annotate_option="-e 'INFO/pArtifact < 0.05' "  when the VCF file is empty so there is no need to reset the variable.
